### PR TITLE
Fix json, text and add urlencoded formats

### DIFF
--- a/src/test/scala/ai/diffy/lifter/HttpLifterSpec.scala
+++ b/src/test/scala/ai/diffy/lifter/HttpLifterSpec.scala
@@ -87,7 +87,6 @@ class HttpLifterSpec extends ParentSpec {
 
         msg.endpoint.get should equal ("endpoint")
         resultFieldMap.get("uri").get should equal (req.uri)
-        resultFieldMap.get("body").get should equal (requestBody)
       }
     }
 


### PR DESCRIPTION
This makes three changes, all to decoding of requests.
1) Text (key = value) is now the default decoding method. It cannot fail. Any line without a key will just be a value.
2) Json requests are treated as fieldmaps at the top level even if the top level is actually a normal map, so censorship now works. It now will make a difference between whether censorship is turned on or off, which is a bit weird... but seems to give a good result.
3) URL decoding now works as a new potential decoding style.